### PR TITLE
Update TimeTrackingEditor to 1.0.14

### DIFF
--- a/data/plugins.php
+++ b/data/plugins.php
@@ -435,15 +435,15 @@ Budget planning based on sub-task time tracking:
     ],
     'timetrackingeditor' => [
       'title' => 'Time Tracking Editor',
-      'version' => '1.0.0',
+      'version' => '1.0.14',
       'author' => 'Stinnux',
       'license' => 'MIT',
       'description' => 'Manually Add and Edit Time Tracking entries, add comments and select billable/not billable to time tracking entries. Export Time Tracking Entries as HTML',
       'homepage' => 'https://github.com/stinnux/kanboard-Timetrackingeditor',
       'readme' => 'https://raw.githubusercontent.com/stinnux/kanboard-Timetrackingeditor/master/README.md',
-      'download' => 'https://github.com/stinnux/kanboard-Timetrackingeditor/releases/download/1.0.0/Timetrackingeditor-1.0.0.zip',
+      'download' => 'https://github.com/stinnux/kanboard-Timetrackingeditor/releases/download/1.0.14/Timetrackingeditor-1.0.14.zip',
       'remote_install' => true,
-      'compatible_version' => '1.0.32',
+      'compatible_version' => '1.0.38',
     ],
     'subtaskdate' => [
         'title' => 'Subtask Due Date',


### PR DESCRIPTION

Timetrackingeditor ist now at 1.0.14.

It is compatible with Kanboard 1.0.38 and uses the new modal dialogs