### PR TITLE
Add Telegram Plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,6 +412,11 @@
                     <p>Show task's comments as tooltip as in older kanboard version.</p>
                     <p><em>By Enrico Frigo</em></p>
                 </dd>
+                <dt><a href="https://github.com/manuvarkey/kanboard-plugin-telegram">Telegram</a></dt>
+                <dd>
+                    <p>Receive individual or project notifications on Telegram.</p>
+                    <p><em>By Manu Varkey</em></p>
+                </dd>
             </dl>
         </section>
     </body>

--- a/plugins.json
+++ b/plugins.json
@@ -610,5 +610,17 @@
         "download": "https://github.com/enricofrigo/kanboard/raw/master/plugin-comment-tooltip/releases/download/v1.0.0/CommentTooltip.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.35"
+    },
+    "telegram": {
+        "title": "Telegram",
+        "version": "1.0.0",
+        "author": "Manu Varkey",
+        "license": "MIT",
+        "description": "Receive individual or project notifications on Telegram.",
+        "homepage": "https://github.com/manuvarkey/kanboard-plugin-telegram",
+        "readme": "https://raw.githubusercontent.com/manuvarkey/kanboard-plugin-telegram/master/README.md",
+        "download": "https://github.com/manuvarkey/kanboard-plugin-telegram/releases/download/v1.0.0/Telegram-1.0.0.zip",
+        "remote_install": true,
+        "compatible_version": ">=1.0.37"
     }
 }


### PR DESCRIPTION
I have made a Telegram plugin for Kanboard by building on the Jabber plugin. I created this pull request to allow Plugin installation from the application.

The project is available here https://github.com/manuvarkey/kanboard-plugin-telegram