### PR TITLE
New version of Milestone plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -361,13 +361,13 @@
     },
     "milestone": {
         "title": "Milestone",
-        "version": "1.1.1",
+        "version": "1.1.2",
         "author": "Olivier Maridat",
         "license": "MIT",
         "description": "Add a section for milestones to show their related tasks.",
         "homepage": "https://github.com/oliviermaridat/kanboard-milestone-plugin",
         "readme": "https://raw.githubusercontent.com/oliviermaridat/kanboard-milestone-plugin/master/README.md",
-        "download": "https://github.com/oliviermaridat/kanboard-milestone-plugin/releases/download/1.1.1/Milestone-1.1.1.zip",
+        "download": "https://github.com/oliviermaridat/kanboard-milestone-plugin/releases/download/1.1.2/Milestone-1.1.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.43"
     },


### PR DESCRIPTION
No big feature, just few stuffs.

Changelogs:
* Add + button in Milestone view to quickly add a new existing task to this milestone
* Show started and due date on Milestone view (available only on Kanboard >1.2, but the plugin is still working for lower versions)
* Use completed date on Gantt view (instead of due date) when available