### PR TITLE
typo in Comment tooltip plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -674,7 +674,7 @@
     },
     "comment-tooltip": {
         "title": "Comment Tooltip",
-        "version": "0.0.1",
+        "version": "1.0.1",
         "author": "Enrico Frigo",
         "license": "MIT",
         "description": "Show task's comments as tooltip as in older kanboard version.",


### PR DESCRIPTION
it downloads and installs 1.0.1 not 0.0.1