### PR TITLE
wiki v0.2.7

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -661,13 +661,13 @@
     },
     "wiki": {
         "title": "Wiki",
-        "version": "0.2.6",
+        "version": "0.2.7",
         "author": "lastlink",
         "license": "MIT",
         "description": "Wiki to document projects.",
         "homepage": "https://github.com/funktechno/kanboard-plugin-wiki",
         "readme": "https://raw.githubusercontent.com/funktechno/kanboard-plugin-wiki/master/README.md",
-        "download": "https://github.com/funktechno/kanboard-plugin-wiki/releases/download/0.2.6-alpha/Wiki-0.2.6.zip",
+        "download": "https://github.com/funktechno/kanboard-plugin-wiki/releases/download/0.2.7-alpha/Wiki-0.2.7.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.37"
     },


### PR DESCRIPTION
A migrations fix for mysql instances. Allows for saving foreign characters in wiki tables.