### PR TITLE
Update Group_assign Version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -85,13 +85,13 @@
     },
     "group_assign": {
         "title": "Group Assign",
-        "version": "0.0.1",
+        "version": "0.0.2",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/0.0.1/Group_assign-0.0.1.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/0.0.2/Group_assign-0.0.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },


### PR DESCRIPTION
Update Group_assign Version
* Supports v1.2.6 Colored Category on Board
* removes details.php override and replaces with a hook

Fixes creecros/Group_assign#8