### PR TITLE
Update Task2pdf Version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -97,13 +97,13 @@
     },
     "Task2pdf": {
         "title": "Task2pdf",
-        "version": "0.0.2",
+        "version": "0.0.3",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Create a printer friendly PDF of a task.",
         "homepage": "https://github.com/creecros/Task2pdf",
         "readme": "https://raw.githubusercontent.com/creecros/Task2pdf/master/README.md",
-        "download": "https://github.com/creecros/Task2pdf/releases/download/0.0.2/Task2pdf-0.0.2.zip",
+        "download": "https://github.com/creecros/Task2pdf/releases/download/0.0.3/Task2pdf-0.0.3.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.46"
     },


### PR DESCRIPTION
Closes creecros/Task2pdf#2

* Now supports \```codeblock``` and \~\~\~codeblock\~\~\~ and will break lines properly in pdf for them.