### PR TITLE
Customizer Plugin version update

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -85,13 +85,13 @@
     },
     "customizer": {
         "title": "Customizer",
-        "version": "0.0.1",
+        "version": "0.0.2",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "GUI to add logo and favicons.",
         "homepage": "https://github.com/creecros/Customizer",
         "readme": "https://raw.githubusercontent.com/creecros/Customizer/master/README.md",
-        "download": "https://github.com/creecros/Customizer/releases/download/0.0.1/Customizer-0.0.1.zip",
+        "download": "https://github.com/creecros/Customizer/releases/download/0.0.2/Customizer-0.0.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },


### PR DESCRIPTION
* Adds login background image url support
* Adds a separate login logo type, so that different logo can be used on login page vs header logo
* Removes default KB logo from main page if no login logo is supplied.
* Adds minimal css to center logo usage in header and login

Fixes creecros/Customizer#2 creecros/Customizer#6