### PR TITLE
Update plugins.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
                 </dd>
                 <dt><a href="https://github.com/BlueTeck/kanboard_plugin_coverimage">Coverimage</a></dt>
                 <dd>
-                    <p>This plugin adds a coverimage function to the board.</p>
+                    <p>This plugin adds a coverimage function to the board, and a project logo function to projects.</p>
                     <p><em>By BlueTeck</em></p>
                 </dd>
                 <dt><a href="https://github.com/kanboard/plugin-database-storage">Database Storage</a></dt>

--- a/index.html
+++ b/index.html
@@ -192,6 +192,11 @@
                     <p>Convert a Task to a PDF, Printer Friendly!</p>
                     <p><em>By Craig Crosby</em></p>
                 </dd>
+                <dt><a href="https://github.com/vistree/kanboard-backlog">Backlog</a></dt>
+                <dd>
+                    <p>Plugin to add a backlog column with full height to project board. One Column to rule them all.</p>
+                    <p><em>By vistree + creecros</em></p>
+                </dd>
                 <dt><a href="https://github.com/kanboard/plugin-broadcast">Broadcast</a></dt>
                 <dd>
                     <p>Plugin to broadcast messages to users via the application or email.</p>

--- a/plugins.json
+++ b/plugins.json
@@ -129,7 +129,7 @@
         "readme": "https://raw.githubusercontent.com/vistree/kanboard-backlog/master/README.md",
         "download": "https://github.com/vistree/kanboard-backlog/releases/download/0.0.2/Backlog-0.0.2.zip",
         "remote_install": true,
-        "compatible_version": ">=1.2.4"
+        "compatible_version": ">=1.0.45"
     },
     "beanstalk": {
         "title": "Beanstalk",

--- a/plugins.json
+++ b/plugins.json
@@ -457,13 +457,13 @@
     },
     "metamagik": {
         "title": "metaMagik",
-        "version": "0.0.4",
+        "version": "0.0.5",
         "author": "Craig Crosby + BlueTeck",
         "license": "MIT",
         "description": "Custom Fields and advanced GUI for managing them, along with Metadata Manager",
         "homepage": "https://github.com/creecros/MetaMagik",
         "readme": "https://github.com/creecros/MetaMagik/blob/master/README.md",
-        "download": "https://github.com/creecros/MetaMagik/releases/download/0.0.4/MetaMagik-0.0.4.zip",
+        "download": "https://github.com/creecros/MetaMagik/releases/download/0.0.5/MetaMagik-0.0.5.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.33"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -119,6 +119,18 @@
         "remote_install": true,
         "compatible_version": ">=1.0.46"
     },
+    "backlog": {
+        "title": "Backlog",
+        "version": "0.0.2",
+        "author": "vistree + creecros",
+        "license": "GPL-3.0",
+        "description": "Plugin to add a backlog column with full height to project board.",
+        "homepage": "https://github.com/vistree/kanboard-backlog",
+        "readme": "https://raw.githubusercontent.com/vistree/kanboard-backlog/master/README.md",
+        "download": "https://github.com/vistree/kanboard-backlog/releases/download/0.0.2/Backlog-0.0.2.zip",
+        "remote_install": true,
+        "compatible_version": ">=1.2.4"
+    },
     "beanstalk": {
         "title": "Beanstalk",
         "version": "1.0.0",

--- a/plugins.json
+++ b/plugins.json
@@ -85,13 +85,13 @@
     },
     "customizer": {
         "title": "Customizer",
-        "version": "0.0.3",
+        "version": "0.0.4",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "GUI to add logo and favicons.",
         "homepage": "https://github.com/creecros/Customizer",
         "readme": "https://raw.githubusercontent.com/creecros/Customizer/master/README.md",
-        "download": "https://github.com/creecros/Customizer/releases/download/0.0.3/Customizer-0.0.3.zip",
+        "download": "https://github.com/creecros/Customizer/releases/download/0.0.4/Customizer-0.0.4.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },


### PR DESCRIPTION
- Fixes creecros/MetaMagik#18
- Update description for coverimage Plugin.
- Add Backlog Plugin
- Fixed compatibility bug in Customizer Plugin, should now support Kanboard >=1.0.42
- Centered text on Login Panel in Customizer Plugin