### PR TITLE
add Synology Chat plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,6 +447,11 @@
                     <p>This plugin adds a Due Date to subtasks.</p>
                     <p><em>By Manuel Raposo</em></p>
                 </dd>
+                <dt><a href="https://github.com/kolossi/plugin-synology-chat">Synology Chat</a></dt>
+                <dd>
+                    <p>Receive individual or project notifications on Synology Chat.</p>
+                    <p><em>By Paul Sweeney</em></p>
+                </dd>
                 <dt><a href="https://github.com/kanboard/plugin-task-board-date">Task Board Date</a></dt>
                 <dd>
                     <p>Add a new date field for tasks to define the visibility on the board and dashboard.</p>

--- a/plugins.json
+++ b/plugins.json
@@ -720,13 +720,13 @@
         "compatible_version": ">=1.0.34"
     },
     "synologychat": {
-        "title": "Synology Chat",
+        "title": "SynologyChat",
         "version": "1.0.0",
         "author": "Paul Sweeney",
         "license": "MIT",
         "description": "Receive individual or project notifications on Synology Chat.",
-        "homepage": "https://github.com/kanboard/plugin-slack",
-        "readme": "https://raw.githubusercontent.com/kanboard/plugin-slack/master/README.md",
+        "homepage": "https://github.com/Kolossi/plugin-synology-chat",
+        "readme": "https://raw.githubusercontent.com/Kolossi/plugin-synology-chat/master/README.md",
         "download": "https://github.com/Kolossi/plugin-synology-chat/releases/download/v1.0.0/SynologyChat-1.0.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.2.6"

--- a/plugins.json
+++ b/plugins.json
@@ -719,6 +719,18 @@
         "remote_install": true,
         "compatible_version": ">=1.0.34"
     },
+    "synologychat": {
+        "title": "Synology Chat",
+        "version": "1.0.0",
+        "author": "Paul Sweeney",
+        "license": "MIT",
+        "description": "Receive individual or project notifications on Synology Chat.",
+        "homepage": "https://github.com/kanboard/plugin-slack",
+        "readme": "https://raw.githubusercontent.com/kanboard/plugin-slack/master/README.md",
+        "download": "https://github.com/Kolossi/plugin-synology-chat/releases/download/v1.0.0/SynologyChat-1.0.0.zip",
+        "remote_install": true,
+        "compatible_version": ">=1.2.6"
+    },
     "timeintervalbutton": {
         "title": "Time Interval Button",
         "version": "0.9.0",


### PR DESCRIPTION
Hi Frédéric,

My first attempt at a plugin.  Synology Chat is a slack-like program available on Synology NAS devices.

I've shamelessly forked your Slack plugin, as Synology Chat uses a simplified version of the slack api - takes just text, no user or icon.  Plus they didn't make it _quite_ the same.

I'm fairly confident in what I've done but although if I drop it in my plugins directory, it shows up in plugins, the settings pages do not show up.

I'm hoping once it's listed in the plugins directory it will come to life?  If not any pointers would be much appreciated.

Regards

Paul Sweeney