### PR TITLE
Update "Notifier" plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -780,14 +780,14 @@
         "compatible_version": ">=1.0.37"
     },
     "updatenotifier": {
-        "title": "Update Notifier",
-        "version": "1.3.2",
+        "title": "UpdateNotifier",
+        "version": "1.3.3",
         "author": "Valentino Pesce",
         "license": "MIT",
         "description": "What is Update Notifier? The Update Notifier is a utility that scans installed plugin and displays a list of updates.",
         "homepage": "https://github.com/kenlog/UpdateNotifier",
         "readme": "https://raw.githubusercontent.com/kenlog/UpdateNotifier/master/README.md",
-        "download": "https://github.com/kenlog/UpdateNotifier/releases/download/v1.3.2/UpdateNotifier-1.3.2.zip",
+        "download": "https://github.com/kenlog/UpdateNotifier/releases/download/v1.3.3/UpdateNotifier-1.3.3.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },


### PR DESCRIPTION
fix: removed space from the plugin name for the correct version update notifications