### PR TITLE
Update plugins.json

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 
         <section id="plugins">
             <h2>Plugins</h2>
-            <p>You can extends the features of Kanboard by installing some extensions:</p>
+            <p>You can extend the features of Kanboard by installing some extensions:</p>
             <h3>Filter Plugins below, by name or content</h3>			
             <input type="text" id="pluginsfilter_input" onkeyup="pluginFilter()" placeholder="Search for plugin.." title="Search input for plugin filter">
             <dl id="pluginsfilter">
@@ -189,9 +189,9 @@
                     <p>GUI to add logos, favicon, customize login page, multiple themes, manage themes, create themes.</p>
                     <p><em>By Craig Crosby</em></p>
                 </dd>
-                <dt><a href="https://github.com/creecros/group_assign">Group assignment for tasks.</a></dt>
+                <dt><a href="https://github.com/creecros/group_assign">Group assignment for tasks</a></dt>
                 <dd>
-                    <p>Plugin adds Group Assignment and additional assignees multiselect for tasks</p>
+                    <p>Plugin adds Group Assignment and additional multiple users assignment for tasks</p>
                     <p><em>By Craig Crosby</em></p>
                 </dd>
                 <dt><a href="https://github.com/creecros/Task2pdf">Task2pdf</a></dt>

--- a/plugins.json
+++ b/plugins.json
@@ -85,13 +85,13 @@
     },
     "customizer": {
         "title": "Customizer",
-        "version": "1.8.1",
+        "version": "1.8.2",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "GUI to add logos, themes, favicons and much more customization.",
         "homepage": "https://github.com/creecros/Customizer",
         "readme": "https://raw.githubusercontent.com/creecros/Customizer/master/README.md",
-        "download": "https://github.com/creecros/Customizer/releases/download/1.8.1/Customizer-1.8.1.zip",
+        "download": "https://github.com/creecros/Customizer/releases/download/1.8.2/Customizer-1.8.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -745,13 +745,13 @@
     },
     "subtaskdate": {
         "title": "SubtaskDueDate",
-        "version": "1.1.0",
+        "version": "1.1.1",
         "author": "Manuel Raposo & Craig Crosby",
         "license": "MIT",
         "description": "This plugin adds a Due Date to subtasks.",
         "homepage": "https://github.com/eSkiSo/Subtaskdate",
         "readme": "https://raw.githubusercontent.com/eSkiSo/Subtaskdate/master/README.md",
-        "download": "https://github.com/eSkiSo/Subtaskdate/releases/download/1.1.0/Subtaskdate-1.1.0.zip",
+        "download": "https://github.com/eSkiSo/Subtaskdate/releases/download/1.1.1/Subtaskdate-1.1.1.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.34"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.2.2",
+        "version": "1.3.0",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.2.2/Group_assign-1.2.2.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.3.0/Group_assign-1.3.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.4.0",
+        "version": "1.4.1",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.4.0/Group_assign-1.4.0.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.4.1/Group_assign-1.4.1.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -85,13 +85,13 @@
     },
     "customizer": {
         "title": "Customizer",
-        "version": "1.8.2",
+        "version": "1.8.3",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "GUI to add logos, themes, favicons and much more customization.",
         "homepage": "https://github.com/creecros/Customizer",
         "readme": "https://raw.githubusercontent.com/creecros/Customizer/master/README.md",
-        "download": "https://github.com/creecros/Customizer/releases/download/1.8.2/Customizer-1.8.2.zip",
+        "download": "https://github.com/creecros/Customizer/releases/download/1.8.3/Customizer-1.8.3.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.4.2",
+        "version": "1.5.0",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.4.2/Group_assign-1.4.2.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.5.0/Group_assign-1.5.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.4.1",
+        "version": "1.4.2",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.4.1/Group_assign-1.4.1.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.4.2/Group_assign-1.4.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.2.1",
+        "version": "1.2.2",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.2.1/Group_assign-1.2.1.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.2.2/Group_assign-1.2.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.3.0",
+        "version": "1.4.0",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.3.0/Group_assign-1.3.0.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.4.0/Group_assign-1.4.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },


### PR DESCRIPTION
## kanboard/Website
- Typo: Change `Extends` to `Extend` on website
- Update description for Group Assign

## creecros/Customizer
- Fixes a Backward compatibility issue for KB Versions > 1.1.0 and < 1.2.4
  - Fixes creecros/Customizer#70 
- Broadens compatibility for APP_VERSIONS that = 'master'
- Fixes creecros/Customizer#72

## creecros/Group_assign
- Minor UI Adjustment
- Assigned users in a group or via Multiselect, will now recieve notifications
- Changing assigned group or any multiselect users will now trigger `EVENT_ASSIGNEE_CHANGE`
- Adds color emphasis to assigned group names
- Fixed a typo in a variable name causing a PHP Warning.
- Task Duplication now includes group assigned and other assignee's
  - Task Duplication to another project includes group assigned and other assignee's, with permissions to the new project
  - Task Movement to another project includes group assigned and other assignee's, with permissions to the new project
- Task Recurrence now includes group assigned and other assignee's in the recurrence.
  - Implements creecros/Group_assign#5

## eSkiSo/Subtaskdate
- Backward compatibility
  - Automatically determines `APP_VERSION` and attaches templates to the dashboard hook.
  - In the event that `APP_VERSION` is `master`, uses `ChangeLog` to determine Kanboard Version.