### PR TITLE
Plugin Versions

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -49,13 +49,13 @@
     },
     "autosubtasks": {
         "title": "Auto Subtask Creation",
-        "version": "0.0.3",
+        "version": "1.0.4",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Automatic action to create subtasks when a task is created or moves column.",
         "homepage": "https://github.com/creecros/AutoSubtasks",
         "readme": "https://raw.githubusercontent.com/creecros/AutoSubtasks/master/README.md",
-        "download": "https://github.com/creecros/AutoSubtasks/releases/download/0.0.3/AutoSubtasks-0.0.3.zip",
+        "download": "https://github.com/creecros/AutoSubtasks/releases/download/1.0.4/AutoSubtasks-1.0.4.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.48"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -109,13 +109,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.5.0",
+        "version": "1.6.0",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.5.0/Group_assign-1.5.0.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.6.0/Group_assign-1.6.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },


### PR DESCRIPTION
## creecros/AutoSubtasks
- Removed previous requirement to also install [Subtaskdate](https://github.com/eSkiSo/Subtaskdate) plugin

## creecros/Group_assign
- creecros/Group_assign#24
- Adds a toggle switch in `Settings > Application settings` to enable group management for `Application Managers`
  - App Managers will be able to fully manage groups, create them, add users to them, remove users from them, etc...