### PR TITLE
Update AttachDocumentsforViewers

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -895,7 +895,7 @@
         "description": "This plugin will allow Project Viewers to attach documents to tasks.",
         "homepage": "https://github.com/hernandezfo/AttachDocumentsforViewers",
         "readme": "https://raw.githubusercontent.com/hernandezfo/AttachDocumentsforViewers/master/README.md",
-        "download": "https://github.com/hernandezfo/AttachDocumentsforViewers/releases/download/0.0.1/AttachDocumentsforViewers-0.0.1.zip",
+        "download": "https://github.com/hernandezfo/AttachDocumentsforViewers/releases/download/0.0.2/AttachDocumentsforViewers-0.0.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.2.5"
     }

--- a/plugins.json
+++ b/plugins.json
@@ -889,7 +889,7 @@
     },
     "AttachDocumentsforViewers": {
         "title": "Attach Documents for Project Viewers",
-        "version": "0.0.1",
+        "version": "0.0.2",
         "author": "Franklin Hernandez",
         "license": "MIT",
         "description": "This plugin will allow Project Viewers to attach documents to tasks.",


### PR DESCRIPTION
Update AttachDocumentsforViewers. Issues Fixed. New version 0.0.2

[AttachDocumentsforViewers-0.0.2.zip](https://github.com/kanboard/website/files/2766601/AttachDocumentsforViewers-0.0.2.zip)

[SourceCode-AttachDocumentsforViewers-0.0.2.zip](https://github.com/kanboard/website/files/2766602/SourceCode-AttachDocumentsforViewers-0.0.2.zip)

