### PR TITLE
Update plugins version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -529,13 +529,13 @@
     },
     "metamagik": {
         "title": "metaMagik",
-        "version": "1.2.4",
+        "version": "1.2.5",
         "author": "Craig Crosby + BlueTeck",
         "license": "MIT",
         "description": "Custom Fields and advanced GUI for managing them, along with Metadata Manager",
         "homepage": "https://github.com/creecros/MetaMagik",
         "readme": "https://github.com/creecros/MetaMagik/blob/master/README.md",
-        "download": "https://github.com/creecros/MetaMagik/releases/download/1.2.4/MetaMagik-1.2.4.zip",
+        "download": "https://github.com/creecros/MetaMagik/releases/download/1.2.5/MetaMagik-1.2.5.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.33"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -529,13 +529,13 @@
     },
     "metamagik": {
         "title": "metaMagik",
-        "version": "1.2.3",
+        "version": "1.2.4",
         "author": "Craig Crosby + BlueTeck",
         "license": "MIT",
         "description": "Custom Fields and advanced GUI for managing them, along with Metadata Manager",
         "homepage": "https://github.com/creecros/MetaMagik",
         "readme": "https://github.com/creecros/MetaMagik/blob/master/README.md",
-        "download": "https://github.com/creecros/MetaMagik/releases/download/1.2.3/MetaMagik-1.2.3.zip",
+        "download": "https://github.com/creecros/MetaMagik/releases/download/1.2.4/MetaMagik-1.2.4.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.33"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -49,13 +49,13 @@
     },
     "autosubtasks": {
         "title": "Auto Subtask Creation",
-        "version": "1.0.4",
+        "version": "2.0.0",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Automatic action to create subtasks when a task is created or moves column.",
         "homepage": "https://github.com/creecros/AutoSubtasks",
         "readme": "https://raw.githubusercontent.com/creecros/AutoSubtasks/master/README.md",
-        "download": "https://github.com/creecros/AutoSubtasks/releases/download/1.0.4/AutoSubtasks-1.0.4.zip",
+        "download": "https://github.com/creecros/AutoSubtasks/releases/download/2.0.0/AutoSubtasks-2.0.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.48"
     },


### PR DESCRIPTION
## creecros/MetaMagik
- Fixes creecros/MetaMagik#36 
  - Duplication to another project now duplicates Metadata
- Added a validation rule to prevent field names containting `.`'s
- Added function to replace and remove whitespace, and special characters in field names.

## creecros/AutoSubtasks
- Implements creecros/AutoSubtasks#6 
  - Option to not duplicate subtasks of same title added
  - Changed a variable name for "apply to all columns"
    - This will cause a breaking change to existing actions for those who upgrade, sorry, wanted to make the variable name more clear as to it's purpose.