### PR TITLE
Update plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -85,13 +85,13 @@
     },
     "customizer": {
         "title": "Customizer",
-        "version": "1.8.4",
+        "version": "1.9.0",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "GUI to add logos, themes, favicons and much more customization.",
         "homepage": "https://github.com/creecros/Customizer",
         "readme": "https://raw.githubusercontent.com/creecros/Customizer/master/README.md",
-        "download": "https://github.com/creecros/Customizer/releases/download/1.8.4/Customizer-1.8.4.zip",
+        "download": "https://github.com/creecros/Customizer/releases/download/1.9.0/Customizer-1.9.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },


### PR DESCRIPTION
## creecros/Customizer
- Adds an option to switch on image cache, to increase site speed.
  - please note, once enabled, cache will need to be cleared before new uploaded images will be visible on site.