### PR TITLE
Update plugins.json

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -255,15 +255,15 @@
                     <p>Allow boards to be sorted by card due date.</p>
                     <p><em>By David Morlitz</em></p>
                 </dd>
-                <dt><a href="https://github.com/kenlog/EncryptedContent">Encrypted Content</a></dt>
-                <dd>
-                    <p>This plugin allows the insertion of text content encrypted in the kanboard database, with the use of random keys.</p>
-                    <p><em>Valentino Pesce</em></p>
-                </dd>
                 <dt><a href="https://github.com/creecros/EmojiSupport">Encrypted Content</a></dt>
                 <dd>
                     <p>Adds EmojiOne Shortcode and Unicode conversions to Markdown in Kanboard.</p>
                     <p><em>Craig Crosby</em></p>
+                </dd>
+                <dt><a href="https://github.com/kenlog/EncryptedContent">Encrypted Content</a></dt>
+                <dd>
+                    <p>This plugin allows the insertion of text content encrypted in the kanboard database, with the use of random keys.</p>
+                    <p><em>Valentino Pesce</em></p>
                 </dd>
                 <dt><a href="https://github.com/kenlog/Essential">Essential</a></dt>
                 <dd>

--- a/plugins.html
+++ b/plugins.html
@@ -260,6 +260,11 @@
                     <p>This plugin allows the insertion of text content encrypted in the kanboard database, with the use of random keys.</p>
                     <p><em>Valentino Pesce</em></p>
                 </dd>
+                <dt><a href="https://github.com/creecros/EmojiSupport">Encrypted Content</a></dt>
+                <dd>
+                    <p>Adds EmojiOne Shortcode and Unicode conversions to Markdown in Kanboard.</p>
+                    <p><em>Craig Crosby</em></p>
+                </dd>
                 <dt><a href="https://github.com/kenlog/Essential">Essential</a></dt>
                 <dd>
                     <p>Essential theme returns a new style to your kanboard.</p>

--- a/plugins.html
+++ b/plugins.html
@@ -360,7 +360,7 @@
                     <p>Use the Mailgun API to send emails and create tasks from emails.</p>
                     <p><em>By Frédéric Guillot</em></p>
                 </dd>
-                <dt><a href="https://github.com/creecros/MarkdownPlus">Encrypted Content</a></dt>
+                <dt><a href="https://github.com/creecros/MarkdownPlus">MarkdownPlus</a></dt>
                 <dd>
                     <p>Improved Markdown, with check boxes, emoji shortcode, inline html, etc...</p>
                     <p><em>Craig Crosby</em></p>

--- a/plugins.html
+++ b/plugins.html
@@ -255,11 +255,6 @@
                     <p>Allow boards to be sorted by card due date.</p>
                     <p><em>By David Morlitz</em></p>
                 </dd>
-                <dt><a href="https://github.com/creecros/EmojiSupport">Encrypted Content</a></dt>
-                <dd>
-                    <p>Adds EmojiOne Shortcode and Unicode conversions to Markdown in Kanboard.</p>
-                    <p><em>Craig Crosby</em></p>
-                </dd>
                 <dt><a href="https://github.com/kenlog/EncryptedContent">Encrypted Content</a></dt>
                 <dd>
                     <p>This plugin allows the insertion of text content encrypted in the kanboard database, with the use of random keys.</p>
@@ -364,6 +359,11 @@
                 <dd>
                     <p>Use the Mailgun API to send emails and create tasks from emails.</p>
                     <p><em>By Frédéric Guillot</em></p>
+                </dd>
+                <dt><a href="https://github.com/creecros/MarkdownPlus">Encrypted Content</a></dt>
+                <dd>
+                    <p>Improved Markdown, with check boxes, emoji shortcode, inline html, etc...</p>
+                    <p><em>Craig Crosby</em></p>
                 </dd>
                 <dt><a href="https://github.com/kanboard/plugin-mattermost">Mattermost</a></dt>
                 <dd>

--- a/plugins.json
+++ b/plugins.json
@@ -769,13 +769,13 @@
     },
     "updatenotifier": {
         "title": "UpdateNotifier",
-        "version": "1.4.1",
+        "version": "1.4.2",
         "author": "Valentino Pesce",
         "license": "MIT",
         "description": "What is Update Notifier? The Update Notifier is a utility that scans installed plugin and displays a list of updates.",
         "homepage": "https://github.com/kenlog/UpdateNotifier",
         "readme": "https://raw.githubusercontent.com/kenlog/UpdateNotifier/master/README.md",
-        "download": "https://github.com/kenlog/UpdateNotifier/releases/download/v1.4.1/UpdateNotifier-1.4.1.zip",
+        "download": "https://github.com/kenlog/UpdateNotifier/releases/download/v1.4.2/UpdateNotifier-1.4.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -709,13 +709,13 @@
     },
     "subtaskdate": {
         "title": "SubtaskDueDate",
-        "version": "1.1.1",
+        "version": "1.1.2",
         "author": "Manuel Raposo & Craig Crosby",
         "license": "MIT",
         "description": "This plugin adds a Due Date to subtasks.",
         "homepage": "https://github.com/eSkiSo/Subtaskdate",
         "readme": "https://raw.githubusercontent.com/eSkiSo/Subtaskdate/master/README.md",
-        "download": "https://github.com/eSkiSo/Subtaskdate/releases/download/1.1.1/Subtaskdate-1.1.1.zip",
+        "download": "https://github.com/eSkiSo/Subtaskdate/releases/download/1.1.2/Subtaskdate-1.1.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.34"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -126,7 +126,7 @@
         "license": "MIT",
         "description": "Improved Markdown, with check boxes, emoji shortcode, inline html, etc...",
         "homepage": "https://github.com/creecros/MarkdownPlus",
-        "readme": "https://raw.githubusercontent.com/creecros/MarkdownPlus/master/README.md,
+        "readme": "https://raw.githubusercontent.com/creecros/MarkdownPlus/master/README.md",
         "download": "https://github.com/creecros/MarkdownPlus/releases/download/1.0.0/MarkdownPlus-1.0.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.46"

--- a/plugins.json
+++ b/plugins.json
@@ -119,6 +119,18 @@
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },
+    "EmojiSupport": {
+        "title": "EmojiSupport",
+        "version": "1.0.0",
+        "author": "Craig Crosby",
+        "license": "MIT",
+        "description": "Adds EmojiOne Shortcode and Unicode conversions to Markdown in Kanboard",
+        "homepage": "https://github.com/creecros/EmojiSupport",
+        "readme": "https://raw.githubusercontent.com/creecros/EmojiSupport/master/README.md,
+        "download": "https://github.com/creecros/EmojiSupport/releases/download/1.0.0/EmojiSupport-1.0.0.zip",
+        "remote_install": true,
+        "compatible_version": ">=1.0.46"
+    },
     "group_assign": {
         "title": "Group_assign",
         "version": "1.7.3",

--- a/plugins.json
+++ b/plugins.json
@@ -119,15 +119,15 @@
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },
-    "EmojiSupport": {
-        "title": "EmojiSupport",
+    "MarkdownPlus": {
+        "title": "MarkdownPlus",
         "version": "1.0.0",
         "author": "Craig Crosby",
         "license": "MIT",
-        "description": "Adds EmojiOne Shortcode and Unicode conversions to Markdown in Kanboard",
-        "homepage": "https://github.com/creecros/EmojiSupport",
-        "readme": "https://raw.githubusercontent.com/creecros/EmojiSupport/master/README.md,
-        "download": "https://github.com/creecros/EmojiSupport/releases/download/1.0.0/EmojiSupport-1.0.0.zip",
+        "description": "Improved Markdown, with check boxes, emoji shortcode, inline html, etc...",
+        "homepage": "https://github.com/creecros/MarkdownPlus",
+        "readme": "https://raw.githubusercontent.com/creecros/MarkdownPlus/master/README.md,
+        "download": "https://github.com/creecros/MarkdownPlus/releases/download/1.0.0/MarkdownPlus-1.0.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.46"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -121,13 +121,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.7.1",
+        "version": "1.7.2",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.7.1/Group_assign-1.7.1.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.7.2/Group_assign-1.7.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -97,13 +97,13 @@
     },
     "customizer": {
         "title": "Customizer",
-        "version": "1.11.2",
+        "version": "1.11.3",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "GUI to add logos, themes, favicons and much more customization.",
         "homepage": "https://github.com/creecros/Customizer",
         "readme": "https://raw.githubusercontent.com/creecros/Customizer/master/README.md",
-        "download": "https://github.com/creecros/Customizer/releases/download/1.11.2/Customizer-1.11.2.zip",
+        "download": "https://github.com/creecros/Customizer/releases/download/1.11.3/Customizer-1.11.3.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.42"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -121,13 +121,13 @@
     },
     "group_assign": {
         "title": "Group_assign",
-        "version": "1.7.2",
+        "version": "1.7.3",
         "author": "Craig Crosby",
         "license": "MIT",
         "description": "Add group assignment and additional assignees multiselect option to tasks.",
         "homepage": "https://github.com/creecros/Group_assign",
         "readme": "https://raw.githubusercontent.com/creecros/Group_assign/master/README.md",
-        "download": "https://github.com/creecros/Group_assign/releases/download/1.7.2/Group_assign-1.7.2.zip",
+        "download": "https://github.com/creecros/Group_assign/releases/download/1.7.3/Group_assign-1.7.3.zip",
         "remote_install": true,
         "compatible_version": ">=1.1.0"
     },


### PR DESCRIPTION
## creecros/Group_assign
- added js was double submiting forms, this removes the second submit
- creecros/Group_assign#37 Separates `assignee:` filter and adds `allassignees:` filter
  - using `allassignees:Username` or `allassignees:Name` will find all tasks assigned to that user regardless of how they have been assigneed, whether in the group or in Other Assignees or Assignee.

## creecros/Customizer
- 1.11.2 revisions were causing an infinite loop on installs using external logins, i.e. oauth, LDAP
  - Reverting to prevent infinite loop
- creecros/Customizer#88

## eSkiSo/Subtaskdate
- fix: illegal offset
  - `PHP message: PHP Warning:  Illegal string offset 'id' in /var/www/app/plugins/Subtaskdate/Model/SubtaskCalendarModel.php on line 80`

## kenlog/UpdateNotifier
- fix: remove empty line and create table 'if not exists'
  - kenlog/UpdateNotifier#11 

## creecros/MarkdownPlus
- first release
- Adds EmojiOne `:shortname:` and Unicode conversions to Markdown in Kanboard. 
- Switch between oldschool github style emoji's or newschool emojione emojis, the choice is yours.
- :shortname: autocomplete
- supports check boxes
- inline html
- markdown extra