### PR TITLE
Update plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -517,13 +517,13 @@
     },
     "metamagik": {
         "title": "metaMagik",
-        "version": "1.3.0",
+        "version": "1.4.0",
         "author": "Craig Crosby + BlueTeck",
         "license": "MIT",
         "description": "Custom Fields and advanced GUI for managing them, along with Metadata Manager",
         "homepage": "https://github.com/creecros/MetaMagik",
         "readme": "https://github.com/creecros/MetaMagik/blob/master/README.md",
-        "download": "https://github.com/creecros/MetaMagik/releases/download/1.3.0/MetaMagik-1.3.0.zip",
+        "download": "https://github.com/creecros/MetaMagik/releases/download/1.4.0/MetaMagik-1.4.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.33"
     },


### PR DESCRIPTION
## creecros/MetaMagik
- creecros/MetaMagik#43 
- Updated key/val field to actually perform like key val
  - `tablename,keycol,valcol` e.g. `users,username,id` 
  - this would create a dropdown list that displays usernames but stores the user_id as the value upon selection.
- Updated list types to include a deselect option.
  - i.e. a user list would create a dropdown of users, but there was no unselect option included, it is now included.
- Added a field based on equals criteria. Select a table, column for criteria, the criteria, and the value column.
  - `tablename,criteria_col,criteria,valcol` e.g. `tasks,project_id,5,title` 
  - this would produce a field with dropdown select, only listing the titles of tasks in project id 5.