### PR TITLE
Update RocketChat plugin to v1.0.7

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -495,10 +495,10 @@
                     <p>Authenticate users with Reverse-Proxy method but populate user information from the LDAP directory.</p>
                     <p><em>By Frédéric Guillot</em></p>
                 </dd>
-                <dt><a href="https://github.com/kanboard/plugin-rocketchat">RocketChat</a></dt>
+                <dt><a href="https://github.com/oliviermaridat/plugin-rocketchat">RocketChat</a></dt>
                 <dd>
                     <p>Receive individual or project notifications on RocketChat.</p>
-                    <p><em>By Frédéric Guillot</em></p>
+                    <p><em>By Frédéric Guillot, Olivier Maridat</em></p>
                 </dd>
                 <dt><a href="https://github.com/ipunkt/KanboardSearch">Search Plugin</a></dt>
                 <dd>

--- a/plugins.json
+++ b/plugins.json
@@ -721,13 +721,13 @@
     },
     "rocketchat": {
         "title": "RocketChat",
-        "version": "1.0.6",
-        "author": "Frédéric Guillot",
+        "version": "1.0.7",
+        "author": "Frédéric Guillot, Olivier Maridat",
         "license": "MIT",
         "description": "Receive individual or project notifications on RocketChat.",
-        "homepage": "https://github.com/kanboard/plugin-rocketchat",
-        "readme": "https://raw.githubusercontent.com/kanboard/plugin-rocketchat/master/README.md",
-        "download": "https://github.com/kanboard/plugin-rocketchat/releases/download/v1.0.6/RocketChat-1.0.6.zip",
+        "homepage": "https://github.com/oliviermaridat/plugin-rocketchat",
+        "readme": "https://raw.githubusercontent.com/oliviermaridat/plugin-rocketchat/master/README.md",
+        "download": "https://github.com/oliviermaridat/plugin-rocketchat/releases/download/v1.0.7/RocketChat-1.0.7.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.37"
     },


### PR DESCRIPTION
Dear @fguillot 

I am willing to maintain the RocketChat plugin. My company is using it and therefore me or my colleagues will be able to update it.

If you are ok with, could you consider to accept this MR:

- RocketChat plugin now targets https://github.com/oliviermaridat/plugin-rocketchat instead of the not maintained https://github.com/kanboard/plugin-rocketchat
- Update RocketChat plugin to v1.0.7 : see [release note](https://github.com/oliviermaridat/plugin-rocketchat/releases/tag/v1.0.7)