### PR TITLE
Update KangarooJump plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -505,13 +505,13 @@
     },
     "kangaroojump": {
         "title": "KangarooJump",
-        "version": "1.0.0",
+        "version": "1.1.0",
         "author": "Valentino Pesce",
         "license": "MIT",
         "description": "You can switch from one task to another by entering number on any page of your Kanboard.",
         "homepage": "https://github.com/kenlog/KangarooJump",
         "readme": "https://raw.githubusercontent.com/kenlog/KangarooJump/master/README.md",
-        "download": "https://github.com/kenlog/KangarooJump/releases/download/1.0.0/KangarooJump-v1.0.0.zip",
+        "download": "https://github.com/kenlog/KangarooJump/releases/download/1.1.0/KangarooJump-v1.1.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.48"
     },


### PR DESCRIPTION
Release v1.1.0
- [Add compatibility with the Moon plugin](https://github.com/kenlog/KangarooJump/commit/c56071ca72fe16274a7bcc138309b7a3e98a5bc0)

Thanks @fguillot