### PR TITLE
Update calendar info with new maintainer info

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -229,13 +229,13 @@
     },
     "calendar": {
         "title": "Calendar",
-        "version": "1.1.1",
-        "author": "Frédéric Guillot",
+        "version": "1.2.0",
+        "author": "Andrew Cziryak",
         "license": "MIT",
         "description": "Embedded calendar into Kanboard.",
-        "homepage": "https://github.com/kanboard/plugin-calendar",
-        "readme": "https://raw.githubusercontent.com/kanboard/plugin-calendar/master/README.md",
-        "download": "https://github.com/kanboard/plugin-calendar/releases/download/v1.1.1/Calendar-1.1.1.zip",
+        "homepage": "https://gitlab.com/smacz/kanboard-plugin-calendar",
+        "readme": "https://gitlab.com/smacz/kanboard-plugin-calendar/-/raw/master/README.md",
+        "download": "https://gitlab.com/smacz/kanboard-plugin-calendar/uploads/8dfb71633c381572df79640aab2c0842/Calendar-1.2.0.zip",
         "remote_install": true,
         "compatible_version": ">=1.2.13"
     },


### PR DESCRIPTION
I've forked the code for the calendar plugin to implement the fix in the PR, with the additional fix that was asked for in the previous GH issue. The source and the binary are now on Gitlab.

Let me know if you want to do something like a "calendar-nextgen" or "calendar-legacy" if you want to maintain a link to your archived version of the plugin on Github.