### PR TITLE
Fixing Greenwing download link

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -427,7 +427,7 @@
         "description": "Greenwing is a kanboard beautify theme with a modern design.",
         "homepage": "https://github.com/Confexion/Greenwing",
         "readme": "https://github.com/Confexion/Greenwing/blob/master/README.md",
-        "download": "https://github.com/Confexion/Greenwing/releases/download/v1.3.1/Greenwing.zip",
+        "download": "https://github.com/Confexion/Greenwing/releases/download/1.3.1/Greenwing.zip",
         "remote_install": true,
         "compatible_version": ">=1.2.9"
     },


### PR DESCRIPTION
Download link had a mistake in the version number, this PR fixes it.