### PR TITLE
Update plugin.json to RocketChat plugin v1.0.9

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -775,7 +775,7 @@
         "description": "Receive individual or project notifications on RocketChat.",
         "homepage": "https://github.com/oliviermaridat/plugin-rocketchat",
         "readme": "https://raw.githubusercontent.com/oliviermaridat/plugin-rocketchat/master/README.md",
-        "download": "https://github.com/oliviermaridat/plugin-rocketchat/releases/download/v1.0.9/RocketChat-1.0.9.zip",
+        "download": "https://github.com/oliviermaridat/plugin-rocketchat/releases/download/v1.0.9/RocketChat-v1.0.9.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.37"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -769,13 +769,13 @@
     },
     "rocketchat": {
         "title": "RocketChat",
-        "version": "1.0.7",
+        "version": "1.0.9",
         "author": "Frédéric Guillot, Olivier Maridat",
         "license": "MIT",
         "description": "Receive individual or project notifications on RocketChat.",
         "homepage": "https://github.com/oliviermaridat/plugin-rocketchat",
         "readme": "https://raw.githubusercontent.com/oliviermaridat/plugin-rocketchat/master/README.md",
-        "download": "https://github.com/oliviermaridat/plugin-rocketchat/releases/download/v1.0.7/RocketChat-1.0.7.zip",
+        "download": "https://github.com/oliviermaridat/plugin-rocketchat/releases/download/v1.0.9/RocketChat-1.0.9.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.37"
     },


### PR DESCRIPTION
New version v1.0.9 of the RocketChat plugin available. A PR have been merged on this plugin to make it work with RocketChat v4.

Thanks!