### PR TITLE
Fix Time Interval Button plugin name.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -876,7 +876,7 @@
         "compatible_version": ">=1.2.10"
     },
     "timeintervalbutton": {
-        "title": "Time Interval Button",
+        "title": "Task Interval Button",
         "version": "0.9.0",
         "author": "Igor Mroz",
         "license": "MIT",


### PR DESCRIPTION
Name of the plugin should be Task Interval Button instead of Time
Interval Button.