### PR TITLE
Updated Signal plugin to version 1.0.2

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -733,13 +733,13 @@
     },
     "signal": {
         "title": "Signal",
-        "version": "1.0.1",
+        "version": "1.0.2",
         "author": "Benedikt Hopmann",
         "license": "MIT",
         "description": "Receive Kanboard notifications on Signal (via signal-cli).",
-        "homepage": "https://github.com/stratmaster/kanboard-plugin-signal",
-        "readme": "https://raw.githubusercontent.com/stratmaster/kanboard-plugin-signal/master/README.md",
-        "download": "https://github.com/stratmaster/kanboard-plugin-signal/releases/download/v1.0.1/Signal-1.0.1.zip",
+        "homepage": "https://github.com/bhopmann/kanboard-plugin-signal",
+        "readme": "https://github.com/bhopmann/kanboard-plugin-signal/blob/master/README.md",
+        "download": "https://github.com/bhopmann/kanboard-plugin-signal/archive/refs/tags/v1.0.2.zip",
         "remote_install": true,
         "compatible_version": ">=1.0.37"
     },


### PR DESCRIPTION
The Github repo fpr Signal plugin has changed from https://github.com/stratmaster/kanboard-plugin-signal to https://github.com/bhopmann/kanboard-plugin-signal. This is reflected in this change as well.