### PR TITLE
Fixing Greenwing version

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -779,7 +779,7 @@
         "readme": "https://github.com/Confexion/Greenwing/blob/master/README.md",
         "remote_install": true,
         "title": "Greenwing",
-        "version": "1.3.1"
+        "version": "1.3.2"
     },
     "group_assign": {
         "author": "Craig Crosby",


### PR DESCRIPTION
Align `version` value with the version in download URL.