### PR TITLE
Remove obsolete CCIT - add DoD

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -260,11 +260,6 @@
                     <p>Adds an automatic action, that allows you to clear the due date of tasks in a specific column, that haven't been moved during a given period.</p>
                     <p><em>By Manfred Hoffmann</em></p>
                 </dd>
-                <dt><a href="https://github.com/Chaosmeister/CCIT">Clickable checkboxes in textareas</a></dt>
-                <dd>
-                    <p>Enable state-saving checkboxes in textareas - requires markdownplus</p>
-                    <p><em>By Tomas Dittmann</em></p>
-                </dd>
                 <dt><a href="https://github.com/kanboard/plugin-client-certificate">Client SSL Certificate Authentication</a></dt>
                 <dd>
                     <p>Use SSL client certificate for Kanboard authentication.</p>
@@ -329,6 +324,11 @@
                 <dd>
                     <p>This plugin stores uploaded files into the database instead of using the local filesystem.</p>
                     <p><em>By Frédéric Guillot</em></p>
+                </dd>
+                <dt><a href="https://github.com/Chaosmeister/DefinitionOfDone">Definition of done</a></dt>
+                <dd>
+                    <p>Adds a simple checklist to the taskview, similar to subtasks. Each entry consists of a title-, a description- and a toggleable "done"-field - compatible with MarkdownPlus</p>
+                    <p><em>By Tomas Dittmann</em></p>
                 </dd>
                 <dt><a href="https://github.com/JustFxDev/kanboard-duedate">Due Date sorting</a></dt>
                 <dd>

--- a/plugins.json
+++ b/plugins.json
@@ -356,23 +356,6 @@
         "title": "CAS Authentication",
         "version": "1.0.0"
     },
-    "CCIT": {
-        "author": "Tomas Dittmann",
-        "compatible_version": ">=1.2.20",
-        "description": "Enable state-saving checkboxes in textareas.<br><span title=\"Warning\" style=\"color: #FF6500; font-size: 1.2em;\">&nbsp;&#x26A0;&nbsp;</span>Requires [MarkdownPlus](https://github.com/creecros/MarkdownPlus/releases)",
-        "download": "https://github.com/Chaosmeister/CCIT/releases/download/1.0.0/CCIT.zip",
-        "has_hooks": true,
-        "has_overrides": false,
-        "has_schema": false,
-        "homepage": "https://github.com/Chaosmeister/CCIT",
-        "is_type": "plugin",
-        "last_updated": "2021-11-23",
-        "license": "Unlicense",
-        "readme": "https://github.com/Chaosmeister/CCIT/blob/main/README.md",
-        "remote_install": true,
-        "title": "clickable checkboxes in textareass",
-        "version": "1.0.0"
-    },
     "chat": {
         "author": "Frédéric Guillot",
         "compatible_version": ">=1.2.3",
@@ -627,6 +610,23 @@
         "remote_install": false,
         "title": "Database Storage",
         "version": "1.0.2"
+    },
+    "DefinitionOfDone": {
+        "author": "Tomas Dittmann",
+        "compatible_version": ">=1.2.32",
+        "description": "This plugin adds a simple checklist to the taskview, similar to subtasks.<br>Each entry consists of a title-, a description- and a toggleable \"done\"-field.<br><span style=\"color: #0044ff; font-size: 1.2em;\">&nbsp;&#x26A0;&nbsp;</span>Compatible with [MarkdownPlus](https://github.com/creecros/MarkdownPlus/releases)",
+        "download": "https://github.com/Chaosmeister/DefinitionOfDone/releases/download/1.0.0/DefinitionOfDone.zip",
+        "has_hooks": true,
+        "has_overrides": true,
+        "has_schema": true,
+        "homepage": "https://github.com/Chaosmeister/DefinitionOfDone",
+        "is_type": "plugin",
+        "last_updated": "2023-08-23",
+        "license": "Unlicense",
+        "readme": "https://github.com/Chaosmeister/DefinitionOfDone/blob/main/README.md",
+        "remote_install": true,
+        "title": "Definition of done",
+        "version": "1.0.0"
     },
     "duedate": {
         "author": "JustFxDev (Fx)",

--- a/plugins.json
+++ b/plugins.json
@@ -614,7 +614,7 @@
     "DefinitionOfDone": {
         "author": "Tomas Dittmann",
         "compatible_version": ">=1.2.32",
-        "description": "This plugin adds a simple checklist to the taskview, similar to subtasks.<br>Each entry consists of a title-, a description- and a toggleable \"done\"-field.<br><span style=\"color: #0044ff; font-size: 1.2em;\">&nbsp;&#x26A0;&nbsp;</span>Compatible with [MarkdownPlus](https://github.com/creecros/MarkdownPlus/releases)",
+        "description": "This plugin adds a simple checklist to the taskview, similar to subtasks. Each entry consists of a title, a description and a toggleable \"**done**\" field. \n &nbsp;⚠️&nbsp; Compatible with [MarkdownPlus](https://github.com/creecros/MarkdownPlus/releases)",
         "download": "https://github.com/Chaosmeister/DefinitionOfDone/releases/download/1.0.0/DefinitionOfDone.zip",
         "has_hooks": true,
         "has_overrides": true,


### PR DESCRIPTION
- CCIT got integrated into MarkdownPlus.
- make DoD publicly available