### PR TITLE
Adding a pre-release of WysiwygMDEditor plugin

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -873,7 +873,7 @@
                 </dd>
                 <dt><a href="https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor">Wysiwyg MD Editor</a></dt>
                 <dd>
-                    <p>Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the rich-text-enabled fields in the KB interface. Every editor may allow for different customizations of functionality, MD features, and UI themes.</p>
+                    <p>Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the markdown textareas in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes.</p>
                     <p><em>By Im[F(x)]</em></p>
                 </dd>
                 <dt><a href="https://github.com/ptr0x01/kanboard-plugin-zulip">Zulip</a></dt>

--- a/plugins.html
+++ b/plugins.html
@@ -746,20 +746,15 @@
                     <p>Receive individual or project notifications on Synology Chat.</p>
                     <p><em>By Paul Sweeney</em></p>
                 </dd>
-                <dt><a href="https://github.com/TimoStahl/kanboard_plugin_taglist">Taglist</a></dt>
-                <dd>
-                    <p>This plugin adds Filter Dropdown with all availiable tags.</p>
-                    <p><em>By TimoStahl</em></p>
-                </dd>
-                <dt><a href="https://github.com/manne65-hd/kanboard-TaskAssignPriorityToCategory">TaskAssignPriorityToCategory</a></dt>
-                <dd>
-                    <p>Adds an automatic action to assign a priority based on a category.</p>
-                    <p><em>By Manfred Hoffmann</em></p>
-                </dd>
                 <dt><a href="https://github.com/greyaz/TableView">TableView</a></dt>
                 <dd>
                     <p>A Kanboard plugin that provides a table view of tasks in your project.</p>
                     <p><em>By greyaz</em></p>
+                </dd>
+                <dt><a href="https://github.com/TimoStahl/kanboard_plugin_taglist">Taglist</a></dt>
+                <dd>
+                    <p>This plugin adds Filter Dropdown with all availiable tags.</p>
+                    <p><em>By TimoStahl</em></p>
                 </dd>
                 <dt><a href="https://github.com/aljawaid/TagManager">TagManager</a></dt>
                 <dd>
@@ -771,6 +766,11 @@
                     <p>Convert a Task to a PDF, Printer Friendly!</p>
                     <p><em>By Craig Crosby</em></p>
                 </dd>
+                <dt><a href="https://github.com/manne65-hd/kanboard-TaskAssignPriorityToCategory">TaskAssignPriorityToCategory</a></dt>
+                <dd>
+                    <p>Adds an automatic action to assign a priority based on a category.</p>
+                    <p><em>By Manfred Hoffmann</em></p>
+                </dd>
                 <dt><a href="https://github.com/kanboard/plugin-task-board-date">Task Board Date</a></dt>
                 <dd>
                     <p>Add a new date field for tasks to define the visibility on the board and dashboard.</p>
@@ -780,11 +780,6 @@
                 <dd>
                     <p>By this Plugin some action buttons are duplicated from sidebar list to corresponding accordion section in Task content view.</p>
                     <p><em>By Andrei Volgin, ipunkt Business Solutions</em></p>
-                </dd>
-                <dt><a href="https://github.com/Chaosmeister/TNID">Task number in details</a></dt>
-                <dd>
-                    <p>Shows the task number in the task details, so if you use the MinimizeSidebar plugin, you can still see the tasknumber</p>
-                    <p><em>By Tomas Dittmann</em></p>
                 </dd>
                 <dt><a href="https://github.com/kenlog/TaskProgressBar">TaskProgressBar</a></dt>
                 <dd>
@@ -811,11 +806,6 @@
                     <p>A clean and high-quality theme for Kanboard. It's aimed at better mobile experiences, common plugin compatibilities, and customization friendly.</p>
                     <p><em>By greyaz</em></p>
                 </dd>
-                <dt><a href="https://gitlab.com/yv-kanboard-plugin/time-machine">Time Machine: Back to the Future</a></dt>
-                <dd>
-                    <p>Add more analytics times datas like time comparison by swimlanes, categories and by dates (only spent time). And a edit form on subtask time tracking</p>
-                    <p><em>By Yohann Valentin</em></p>
-                </dd>
                 <dt><a href="https://github.com/mrozigor/kanboard-add-time-interval-plugin">Time Interval Button</a></dt>
                 <dd>
                     <p>Simple plugins which adds button to incrementally change time spent on task.</p>
@@ -826,10 +816,30 @@
                     <p>Working timetable management for users.</p>
                     <p><em>By Frédéric Guillot</em></p>
                 </dd>
+                <dt><a href="https://gitlab.com/yv-kanboard-plugin/time-machine">Time Machine: Back to the Future</a></dt>
+                <dd>
+                    <p>Add more analytics times datas like time comparison by swimlanes, categories and by dates (only spent time). And a edit form on subtask time tracking</p>
+                    <p><em>By Yohann Valentin</em></p>
+                </dd>
                 <dt><a href="https://github.com/stinnux/kanboard-Timetrackingeditor">Time Tracking Editor</a></dt>
                 <dd>
                     <p>Manually Add and Edit Time Tracking entries, add comments and select billable/not billable to time tracking entries. Export Time Tracking Entries as HTML.</p>
                     <p><em>By Stinnux</em></p>
+                </dd>
+                <dt><a href="https://github.com/Chaosmeister/TNID">Task number in details</a></dt>
+                <dd>
+                    <p>Shows the task number in the task details, so if you use the MinimizeSidebar plugin, you can still see the tasknumber</p>
+                    <p><em>By Tomas Dittmann</em></p>
+                </dd>
+                <dt><a href="https://github.com/kenlog/UpdateNotifier">Update Notifier</a></dt>
+                <dd>
+                    <p>What is Update Notifier? The Update Notifier is a utility that scans installed plugin and displays a list of updates.</p>
+                    <p><em>By Valentino Pesce</em></p>
+                </dd>
+                <dt><a href="https://github.com/aljawaid/URLCleaner">URLCleaner</a></dt>
+                <dd>
+                    <p>This simple tool extends the rewriting of browser URLs for your Kanboard application. Sanitize those long URLs automatically creating neat pretty easy to remember bookmarks. This plugin extends URLs from the core and from plugins. <a href="https://docs.kanboard.org/v1/admin/url-rewriting/" target="_blank" title="Opens in a new window">URL Rewriting</a> must be correctly configured for this plugin to function properly.</p>
+                    <p><em>By aljawaid</em></p>
                 </dd>
                 <dt><a href="https://github.com/greyaz/WechatWorkNotifier">Wechat Work Notifier</a></dt>
                 <dd>
@@ -846,30 +856,25 @@
                     <p>This plugin add new features to Kanboard. Weighted voting for the evaluation of group activities in Kanboard.</p>
                     <p><em>By Manel Perez</em></p>
                 </dd>
-                <dt><a href="https://github.com/funktechno/kanboard-plugin-wiki">Wiki</a></dt>
-                <dd>
-                    <p>Wiki to document projects.</p>
-                    <p><em>By lastlink</em></p>
-                </dd>
                 <dt><a href="https://github.com/bw-hro/WeKanboard">WeKanboard</a></dt>
                 <dd>
                     <p>Yet another theme for Kanboard. Strongly inspired by the style of Wekan. Supports the Customizer plugin.</p>
                     <p><em>By Benno Waldhauer</em></p>
+                </dd>
+                <dt><a href="https://github.com/funktechno/kanboard-plugin-wiki">Wiki</a></dt>
+                <dd>
+                    <p>Wiki to document projects.</p>
+                    <p><em>By lastlink</em></p>
                 </dd>
                 <dt><a href="https://github.com/EpocDotFr/kanboard-wunderlist">Wunderlist</a></dt>
                 <dd>
                     <p>This plugin allows you to import Wunderlist tasks and lists directly from the user interface of Kanboard by uploading a Wunderlist export file.</p>
                     <p><em>By Maxime (Epoc)</em></p>
                 </dd>
-                <dt><a href="https://github.com/kenlog/UpdateNotifier">Update Notifier</a></dt>
+                <dt><a href="https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor">Wysiwyg MD Editor</a></dt>
                 <dd>
-                    <p>What is Update Notifier? The Update Notifier is a utility that scans installed plugin and displays a list of updates.</p>
-                    <p><em>By Valentino Pesce</em></p>
-                </dd>
-                <dt><a href="https://github.com/aljawaid/URLCleaner">URLCleaner</a></dt>
-                <dd>
-                    <p>This simple tool extends the rewriting of browser URLs for your Kanboard application. Sanitize those long URLs automatically creating neat pretty easy to remember bookmarks. This plugin extends URLs from the core and from plugins. <a href="https://docs.kanboard.org/v1/admin/url-rewriting/" target="_blank" title="Opens in a new window">URL Rewriting</a> must be correctly configured for this plugin to function properly.</p>
-                    <p><em>By aljawaid</em></p>
+                    <p>Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the rich-text-enabled fields in the KB interface. Every editor may allow for different customizations of functionality, MD features, and UI themes.</p>
+                    <p><em>By Im[F(x)]</em></p>
                 </dd>
                 <dt><a href="https://github.com/ptr0x01/kanboard-plugin-zulip">Zulip</a></dt>
                 <dd>

--- a/plugins.json
+++ b/plugins.json
@@ -2413,6 +2413,23 @@
         "title": "Wiki",
         "version": "0.3.2"
     },
+    "WysiwygMDEditor": {
+        "author": "Im[F(x)]",
+        "compatible_version": ">=1.2.33",
+        "description": "Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the rich-text-enabled fields in the KB interface. Every editor may allow for different customizations of functionality, MD features, and UI themes.",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.1/WysiwygMDEditor-0.5.1.zip",
+        "has_hooks": true,
+        "has_overrides": false,
+        "has_schema": false,
+        "homepage": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor",
+        "is_type": "plugin",
+        "last_updated": "2024-02-15",
+        "license": "MIT",
+        "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
+        "remote_install": true,
+        "title": "Wysiwyg MD Editor",
+        "version": "0.5.1"
+    },
     "zulip": {
         "author": "Peter Fejer",
         "compatible_version": ">=1.2.5",

--- a/plugins.json
+++ b/plugins.json
@@ -2416,8 +2416,8 @@
     "WysiwygMDEditor": {
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
-        "description": "Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the rich-text-enabled fields in the KB interface. Every editor may allow for different customizations of functionality, MD features, and UI themes.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.1/WysiwygMDEditor-0.5.1.zip",
+        "description": "Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the markdown textareas in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes.",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.2/WysiwygMDEditor-0.5.2.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,
@@ -2428,7 +2428,7 @@
         "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
         "remote_install": true,
         "title": "Wysiwyg MD Editor",
-        "version": "0.5.1"
+        "version": "0.5.2"
     },
     "zulip": {
         "author": "Peter Fejer",


### PR DESCRIPTION
https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor
* adding entries for my new plugin WysiwygMDEditor in both the json and the html files for plugins
* also, since the json is alphabetically sorted by plugin name, I allowed myself to reorder the entries in the html file (from letter T to letter Z) so that their order matches the json order

---

I also noted that in the given interval of letter T to letter Z, there are 2x plugins that are listed in the HTML but are not present in the JSON even though they have downloadable releases: 
* https://github.com/kanboard/plugin-task-board-date
* https://github.com/kanboard/plugin-timetable

Both are by Frédéric Guillot. Maybe there's a reason for that, I am just giving you the heads up if it was not intentional.

Yet, there's another even stranger thing - in JSON there are multiple plugins by **Tagirijus** and NONE of them is enlisted in the HTML. I don't know if this was author's intention or just lack of effort to keep things consistent.

Anyway, please, look into those issues.
And consider letting my plugin to the official listing ;)

Thanks,
Ilian