### PR TITLE
update WysiwygMDEditor plugin to v0.5.3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2417,18 +2417,18 @@
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
         "description": "Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the markdown textareas in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.2/WysiwygMDEditor-0.5.2.zip",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.3/WysiwygMDEditor-0.5.3.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,
         "homepage": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor",
         "is_type": "plugin",
-        "last_updated": "2024-02-15",
+        "last_updated": "2024-02-21",
         "license": "MIT",
         "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
         "remote_install": true,
-        "title": "Wysiwyg MD Editor",
-        "version": "0.5.2"
+        "title": "WysiwygMDEditor",
+        "version": "0.5.3"
     },
     "zulip": {
         "author": "Peter Fejer",


### PR DESCRIPTION
## v0.5.3

* Added translations for common languages DE, ES, FR, IT, PT, RU (using Google Translate)
* Translation for "en_US" is set to default if a language pack is missing
* Hiding rendering options until rendering is actually implemented 
