### PR TITLE
* update WysiwygMDEditor plugin to v0.5.4

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2417,18 +2417,18 @@
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
         "description": "Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the markdown textareas in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.3/WysiwygMDEditor-0.5.3.zip",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.4/WysiwygMDEditor-0.5.4.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,
         "homepage": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor",
         "is_type": "plugin",
-        "last_updated": "2024-02-21",
+        "last_updated": "2024-03-15",
         "license": "MIT",
         "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
         "remote_install": true,
         "title": "WysiwygMDEditor",
-        "version": "0.5.3"
+        "version": "0.5.4"
     },
     "zulip": {
         "author": "Peter Fejer",


### PR DESCRIPTION
## v0.5.4

* Added CSP rules for both `EasyMDE` and `StackEdit+` to be allowed to open within an iframe.