### PR TITLE
updated WysiwygMDEditor plugin to v0.9.0

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -365,7 +365,7 @@
                     <p>Extend comment by email with templates and reply-to</p>
                     <p><em>Rens Sikma</em></p>
                 </dd>
-                <dt><a href="https://github.com/aljawaid/FontSwitcher">FontSwitcher</dt>
+                <dt><a href="https://github.com/aljawaid/FontSwitcher">FontSwitcher</a></dt>
                 <dd>
                     <p>Choose a new font style from a variety of self-hosted fonts replacing the default 'Helvetica Neue' (Mac), and 'Arial' (Windows) fonts to a different typeface giving your application a fresh new look. Improve readability and reduce eye strain by choosing from different styles of sans-serif fonts or select an article-type serif type or even a code-type monospace style. Font styles are applied instantly across the site for all users.</p>
                     <p><em>By aljawaid</em></p>

--- a/plugins.html
+++ b/plugins.html
@@ -878,7 +878,7 @@
                 </dd>
                 <dt><a href="https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor">Wysiwyg MD Editor</a></dt>
                 <dd>
-                    <p>Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the markdown textareas in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes.</p>
+                    <p>Integrates external MD editors into Kanboard in order to conveniently edit and preview the markdown textareas, as well as render the markdown fields in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes. Rendering can parametrize theme, code highlight, and background transparency.</p>
                     <p><em>By Im[F(x)]</em></p>
                 </dd>
                 <dt><a href="https://github.com/ptr0x01/kanboard-plugin-zulip">Zulip</a></dt>

--- a/plugins.json
+++ b/plugins.json
@@ -2434,7 +2434,7 @@
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
         "description": "Integrates external MD editors into Kanboard in order to conveniently edit and preview the markdown textareas, as well as render the markdown fields in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes. Rendering can parametrize theme, code highlight, and background transparency.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.9/WysiwygMDEditor-0.9.9.zip",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.0/WysiwygMDEditor-0.9.0.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,

--- a/plugins.json
+++ b/plugins.json
@@ -2433,19 +2433,19 @@
     "WysiwygMDEditor": {
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
-        "description": "Integrates external MD editors into Kanboard in order to conveniently edit/preview (and eventually render) the markdown textareas in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.5.4/WysiwygMDEditor-0.5.4.zip",
+        "description": "Integrates external MD editors into Kanboard in order to conveniently edit and preview the markdown textareas, as well as render the markdown fields in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes. Rendering can parametrize theme, code highlight, and background transparency.",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.9/WysiwygMDEditor-0.9.9.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,
         "homepage": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor",
         "is_type": "plugin",
-        "last_updated": "2024-03-15",
+        "last_updated": "2024-04-05",
         "license": "MIT",
         "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
         "remote_install": true,
         "title": "WysiwygMDEditor",
-        "version": "0.5.4"
+        "version": "0.9.0"
     },
     "zulip": {
         "author": "Peter Fejer",


### PR DESCRIPTION
* Option for custom rendering of markdown fields (using `EasyMDE` locally with JavaScript).
* Rendering can be parametrized with theme, code highlight, and background transparency.
* Style fixes for `EasyMDE` preview and rendering.
* Updates for locale texts.
* fixed an unclosed <a> tag in plugins.html of kanboard-website