### PR TITLE
update WysiwygMDEditor plugin to v0.9.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2434,18 +2434,18 @@
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
         "description": "Integrates external MD editors into Kanboard in order to conveniently edit and preview the markdown textareas, as well as render the markdown fields in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes. Rendering can parametrize theme, code highlight, and background transparency.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.0/WysiwygMDEditor-0.9.0.zip",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.1/WysiwygMDEditor-0.9.1.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,
         "homepage": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor",
         "is_type": "plugin",
-        "last_updated": "2024-04-05",
+        "last_updated": "2024-04-20",
         "license": "MIT",
         "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
         "remote_install": true,
         "title": "WysiwygMDEditor",
-        "version": "0.9.0"
+        "version": "0.9.1"
     },
     "zulip": {
         "author": "Peter Fejer",


### PR DESCRIPTION
* Fixed a major bug that caused markdown text to be distorted when rendered with `EasyMDE`.
* Fixed proper viewing of the settings page with the normal markdown renderer.
* Rearranged some assets, fixed some styles, encapsulated some globally visible code.
* Configured GitHub Actions to perform automatic code checks.