### PR TITLE
update WysiwygMDEditor plugin to v0.9.4

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2451,18 +2451,18 @@
         "author": "Im[F(x)]",
         "compatible_version": ">=1.2.33",
         "description": "Integrates external MD editors into Kanboard in order to conveniently edit and preview the markdown textareas, as well as render the markdown fields in the Kanboard interface. Each editor may allow for different customizations of functionality, MD features, and UI themes. Rendering can parametrize theme, code highlight, and background transparency.",
-        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.1/WysiwygMDEditor-0.9.1.zip",
+        "download": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/releases/download/v0.9.4/WysiwygMDEditor-0.9.4.zip",
         "has_hooks": true,
         "has_overrides": false,
         "has_schema": false,
         "homepage": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor",
         "is_type": "plugin",
-        "last_updated": "2024-04-20",
+        "last_updated": "2024-06-07",
         "license": "MIT",
         "readme": "https://github.com/imfx77/kanboard-plugin-Wysiwyg-MD-Editor/blob/master/README.md",
         "remote_install": true,
         "title": "WysiwygMDEditor",
-        "version": "0.9.1"
+        "version": "0.9.4"
     },
     "zulip": {
         "author": "Peter Fejer",


### PR DESCRIPTION
## v0.9.4

_(most recent changes are listed on top):_
* Integrated a **Font Awesome Icons Picker** into `EasyMDE` and as an optional button in the markdown edit toolbar.
* Reworked settings sections layout and descriptions.

## v0.9.3

_(most recent changes are listed on top):_
* Integrated an **Emoji Picker** into `EasyMDE` and as an optional button in the markdown edit toolbar.

## v0.9.2

_(most recent changes are listed on top):_
* The **English** version of `StackEdit+` is no longer available online, so removing it.
* Adding the basic **English** version of `StackEdit` and the **Chinese** version of `StackEdit+` instead.
* Thus, everyone can choose for himself which editor fits his needs better.
