### PR TITLE
Add "Global Search Plugin" plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -900,6 +900,23 @@
         "title": "Glancer",
         "version": "2.7.1"
     },
+    "global-search": {
+        "author": "Valentino Pesce",
+        "compatible_version": ">=1.2.32",
+        "description": "The Global Search Plugin adds a powerful global search functionality to Kanboard, allowing users to search for tasks, comments, and projects across all available projects they have access to. The search results are filtered by permissions, ensuring that users only see the content they are authorized to view. The search results can also be filtered to display only tasks, comments, or projects.",
+        "download": "https://github.com/kenlog/global-search-kanboard/releases/download/v1.0.0/Globalsearch.zip",
+        "has_hooks": true,
+        "has_overrides": false,
+        "has_schema": false,
+        "homepage": "https://github.com/kenlog/global-search-kanboard",
+        "is_type": "plugin",
+        "last_updated": "2024-09-21",
+        "license": "MIT",
+        "readme": "https://raw.githubusercontent.com/kenlog/global-search-kanboard/refs/heads/master/README.md",
+        "remote_install": true,
+        "title": "Global Search",
+        "version": "1.0.0"
+    },
     "gogs-webhook": {
         "author": "Frédéric Guillot",
         "compatible_version": ">=1.0.37",
@@ -967,23 +984,6 @@
         "remote_install": true,
         "title": "Greenwing",
         "version": "1.3.2"
-    },
-    "global-search": {
-        "author": "Valentino Pesce",
-        "compatible_version": ">=1.2.32",
-        "description": "The Global Search Plugin adds a powerful global search functionality to Kanboard, allowing users to search for tasks, comments, and projects across all available projects they have access to. The search results are filtered by permissions, ensuring that users only see the content they are authorized to view. The search results can also be filtered to display only tasks, comments, or projects.",
-        "download": "https://github.com/kenlog/global-search-kanboard/releases/download/v1.0.0/Globalsearch.zip",
-        "has_hooks": true,
-        "has_overrides": false,
-        "has_schema": false,
-        "homepage": "https://github.com/kenlog/global-search-kanboard",
-        "is_type": "plugin",
-        "last_updated": "2024-09-21",
-        "license": "MIT",
-        "readme": "https://raw.githubusercontent.com/kenlog/global-search-kanboard/refs/heads/master/README.md",
-        "remote_install": true,
-        "title": "Global Search",
-        "version": "1.0.0"
     },
     "group_assign": {
         "author": "Craig Crosby",

--- a/plugins.json
+++ b/plugins.json
@@ -934,6 +934,23 @@
         "title": "Google Authentication",
         "version": "1.0.8"
     },
+    "global-search": {
+        "author": "Valentino Pesce",
+        "compatible_version": ">=1.2.32",
+        "description": "The Global Search Plugin adds a powerful global search functionality to Kanboard, allowing users to search for tasks, comments, and projects across all available projects they have access to. The search results are filtered by permissions, ensuring that users only see the content they are authorized to view. The search results can also be filtered to display only tasks, comments, or projects.",
+        "download": "https://github.com/kenlog/global-search-kanboard/releases/download/v1.0.0/Globalsearch.zip",
+        "has_hooks": true,
+        "has_overrides": false,
+        "has_schema": false,
+        "homepage": "https://github.com/kenlog/global-search-kanboard",
+        "is_type": "plugin",
+        "last_updated": "2024-09-21",
+        "license": "MIT",
+        "readme": "https://raw.githubusercontent.com/kenlog/global-search-kanboard/refs/heads/master/README.md",
+        "remote_install": true,
+        "title": "Global Search",
+        "version": "1.0.0"
+    },
     "GrabScroll": {
         "author": "Ramón Cahenzli",
         "compatible_version": ">=1.2.10",

--- a/plugins.json
+++ b/plugins.json
@@ -934,23 +934,6 @@
         "title": "Google Authentication",
         "version": "1.0.8"
     },
-    "global-search": {
-        "author": "Valentino Pesce",
-        "compatible_version": ">=1.2.32",
-        "description": "The Global Search Plugin adds a powerful global search functionality to Kanboard, allowing users to search for tasks, comments, and projects across all available projects they have access to. The search results are filtered by permissions, ensuring that users only see the content they are authorized to view. The search results can also be filtered to display only tasks, comments, or projects.",
-        "download": "https://github.com/kenlog/global-search-kanboard/releases/download/v1.0.0/Globalsearch.zip",
-        "has_hooks": true,
-        "has_overrides": false,
-        "has_schema": false,
-        "homepage": "https://github.com/kenlog/global-search-kanboard",
-        "is_type": "plugin",
-        "last_updated": "2024-09-21",
-        "license": "MIT",
-        "readme": "https://raw.githubusercontent.com/kenlog/global-search-kanboard/refs/heads/master/README.md",
-        "remote_install": true,
-        "title": "Global Search",
-        "version": "1.0.0"
-    },
     "GrabScroll": {
         "author": "Ramón Cahenzli",
         "compatible_version": ">=1.2.10",
@@ -984,6 +967,23 @@
         "remote_install": true,
         "title": "Greenwing",
         "version": "1.3.2"
+    },
+    "global-search": {
+        "author": "Valentino Pesce",
+        "compatible_version": ">=1.2.32",
+        "description": "The Global Search Plugin adds a powerful global search functionality to Kanboard, allowing users to search for tasks, comments, and projects across all available projects they have access to. The search results are filtered by permissions, ensuring that users only see the content they are authorized to view. The search results can also be filtered to display only tasks, comments, or projects.",
+        "download": "https://github.com/kenlog/global-search-kanboard/releases/download/v1.0.0/Globalsearch.zip",
+        "has_hooks": true,
+        "has_overrides": false,
+        "has_schema": false,
+        "homepage": "https://github.com/kenlog/global-search-kanboard",
+        "is_type": "plugin",
+        "last_updated": "2024-09-21",
+        "license": "MIT",
+        "readme": "https://raw.githubusercontent.com/kenlog/global-search-kanboard/refs/heads/master/README.md",
+        "remote_install": true,
+        "title": "Global Search",
+        "version": "1.0.0"
     },
     "group_assign": {
         "author": "Craig Crosby",


### PR DESCRIPTION
Hello Master @fguillot, it’s been a while since I last contributed a plugin, but here I am with a new one that I believe is truly useful, and I hope it will be appreciated by the community.

Description

The Global Search Plugin adds a powerful global search functionality to Kanboard, allowing users to search for tasks, comments, and projects across all available projects they have access to. The search results are filtered by permissions, ensuring that users only see the content they are authorized to view. The search results can also be filtered to display only tasks, comments, or projects.