### PR TITLE
Add ModernChat plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1563,6 +1563,23 @@
         "title": "Model Context Protocol",
         "version": "1.0.0"
     },
+  "ModernChat": {
+    "author": "ModernChat",
+    "compatible_version": ">=1.2.13",
+    "description": "Modern chat for Kanboard: All-channel, groups, DMs, attachments, deletions, emoji and modern UI.",
+    "download": "https://github.com/lowbirdui/ModernChat/releases/download/v1.0.2/ModernChat-1.0.2.zip",
+    "has_hooks": true,
+    "has_overrides": false,
+    "has_schema": true,
+    "homepage": "https://github.com/lowbirdui/ModernChat",
+    "is_type": "plugin",
+    "last_updated": "2026-06-09",
+    "license": "MIT",
+    "readme": "https://github.com/lowbirdui/ModernChat/blob/main/README.md",
+    "remote_install": true,
+    "title": "ModernChat",
+    "version": "1.0.2"
+  },
     "moon": {
         "author": "Valentino Pesce",
         "compatible_version": ">=1.0.48",


### PR DESCRIPTION
Add ModernChat to the Kanboard plugin directory.

Release asset: https://github.com/lowbirdui/ModernChat/releases/download/v1.0.2/ModernChat-1.0.2.zip
Homepage: https://github.com/lowbirdui/ModernChat
Version: 1.0.2
Compatible Kanboard version: >=1.2.13
